### PR TITLE
商品編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,10 +46,6 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     @category = @item.category
     @categories = Category.roots.all
-    @grandchild = []
-      @categories.each do |root|
-        @grandchild << root.indirects.all
-      end
     @conditions = Condition.all
     @large_classes = LargeClass.all
     @middle_classes = MiddleClass.all
@@ -63,8 +59,6 @@ class ItemsController < ApplicationController
   def update
     @item = Item.find(params[:id])
     @item.update(item_params)
-    binding.pry
-
   end
 
   def confirm

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,6 +56,7 @@ class ItemsController < ApplicationController
     @small_classes = SmallClass.all
     @shipping_fee_payers = ShippingFeePayer.all
     @shipping_days = ShippingDay.all
+    @price = @item.price
     render layout: 'second_application'
   end
 

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -100,9 +100,11 @@
           .s__Price__Fee
             %label{for: ""} 販売手数料 (10%)
             %output#fee{type:  "number"} 
+              = "¥ " + (@price * 0.1).to_i.floor.to_s(:delimited)
           .s__Price__Profit
             %label.box5__itemfont2{for:  ""} 販売利益
             %output#profit{type: "number"} 
+              = "¥ " + (@price * 0.9).to_i.floor.to_s(:delimited)
         / <haml_silent></haml_silent>
       .s__Content__Terms
         %p

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -10,22 +10,18 @@
           %span.hissu 必須
         %p.saidai10 最大10枚までアップロードできます
         .s__ContentImage__Image
-          -# = f.file_field
           ドラッグアンドドロップ
           %bl
             またはクリックしてファイルをアップロード
       .s__Content__Name__Description
-        / 商品名
         .s__Content__Name
           %label.box2font{for: ""} 商品名
           %span.hissu 必須
           %div
             = f.text_field :name, class:"s__Content__Nametittle" , placeholder:" 商品名（必須 40文字まで)"
-        / 商品の説明
         .s__Content__Description
           %label.box2font{for: ""} 商品の説明
           %span.hissu 必須
-          -# %textarea.s__contemt__text{cols:  "80", name:"description", placeholder:  "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", rows:  "8"}
           = f.text_area :description, class:"s__contemt__text" , placeholder:"商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
       .s__Exhibition__Details
         %h2.box3__itemfont1 商品の詳細
@@ -43,16 +39,6 @@
             %label{for: ""}
             %div
               = f.collection_select(:small_class_id, @small_classes, :id, :name, class: "s__box3")
-          -# .s__Details__Size
-          -#   %label.box3__itemfont2{for: ""} サイズ
-          -#   %span.hissu 必須
-          -#   %div
-          -#     = f.collection_select(:size, @, :id, :name, class: "s__box3"):size
-          -#     %option{value: ""}
-          -#     %option{value: ""}
-          -#     %option{value: ""}
-          -#     %option{value: ""}
-          -#     %option{value: ""}
           .s__Details__State
             %label.box3__itemfont2{for: ""} 商品の状態
             %span.hissu 必須
@@ -69,20 +55,6 @@
             %span.hissu 必須
             %div
               = f.collection_select(:shipping_fee_payer_id, @shipping_fee_payers, :id, :payer, class: "s__box4")
-          -# .s__delivery__Configuration
-          -#   %label{for: ""} 配送の方法
-          -#   %span.hissu 必須
-          -#   %div
-          -#     -# = f.collection_select  class: "s__box4"
-          -#     %option{value: ""}
-          -#     %option{value: ""}
-          -# .s__delivery__Configuration
-          -#   %label{for: ""} 発送元の地域
-          -#   %span.hissu 必須
-          -#   %div
-          -#     -# = f.collection_select class: "s__box4"
-          -#     %option{value: ""}
-          -#     %option{value: ""}
           .s__delivery__Configuration
             %label{for: ""} 発送までの日数
             %span.hissu 必須
@@ -105,7 +77,6 @@
             %label.box5__itemfont2{for:  ""} 販売利益
             %output#profit{type: "number"} 
               = "¥ " + (@price * 0.9).to_i.floor.to_s(:delimited)
-        / <haml_silent></haml_silent>
       .s__Content__Terms
         %p
           %span{style: "color:#33aaf0"}> 禁止されている出品


### PR DESCRIPTION
# what
商品編集機能の実装
1. すでに登録済みの商品について、編集ページを表示することができる
https://gyazo.com/522c3a184ba702a625768bbac569c54f
2. 登録内容の変更ができる
3. 2で変更した内容を更新ボタンをクリックすることで更新して、DBにてそれが確認できる
https://gyazo.com/bf2d9a49e22cc004439d7c9379bc0809

※上記のgyazoではDBに登録されている商品の名前を変更して保存している。
（"アメリカンイーグル ポロシャツ"　→　"１"）

# why
一度出品した商品の情報について変更することがありうるため、必要な最低限の機能として実装。